### PR TITLE
Optionally keep dataset as draft after resource upload

### DIFF
--- a/ckanext/cloudstorage/fanstatic/scripts/cloudstorage-multipart-upload.js
+++ b/ckanext/cloudstorage/fanstatic/scripts/cloudstorage-multipart-upload.js
@@ -356,12 +356,14 @@ ckan.module('cloudstorage-multipart-upload', function($, _) {
 
         _onFinishUpload: function() {
             var self = this;
+            var keepDraft = this._pressedSaveButton == 'again' || this._pressedSaveButton == 'go-dataset';
             this.sandbox.client.call(
                 'POST',
                 'cloudstorage_finish_multipart',
                 {
                     'uploadId': this._uploadId,
-                    'id': this._resourceId
+                    'id': this._resourceId,
+                    'keepDraft': keepDraft
                 },
                 function (data) {
 

--- a/ckanext/cloudstorage/logic/action/multipart.py
+++ b/ckanext/cloudstorage/logic/action/multipart.py
@@ -184,6 +184,7 @@ def finish_multipart(context, data_dict):
 
     :param context:
     :param data_dict: dict with required key `uploadId` - id of Multipart Upload that should be finished
+    :param keepDraft: true if dataset should be kept as a draft after the file is uploaded
     :returns: None
     :rtype: NoneType
 
@@ -216,7 +217,7 @@ def finish_multipart(context, data_dict):
         pkg_dict = toolkit.get_action('package_show')(
             context.copy(), {'id': res_dict['package_id']})
 
-        if pkg_dict['state'] == 'draft' and not data_dict.get('keepDraft'):
+        if pkg_dict['state'] == 'draft' and not toolkit.asbool(data_dict.get('keepDraft')):
             toolkit.get_action('package_patch')(
                 dict(context.copy(), allow_state_change=True),
                 dict(id=pkg_dict['id'], state='active')

--- a/ckanext/cloudstorage/logic/action/multipart.py
+++ b/ckanext/cloudstorage/logic/action/multipart.py
@@ -216,7 +216,7 @@ def finish_multipart(context, data_dict):
         pkg_dict = toolkit.get_action('package_show')(
             context.copy(), {'id': res_dict['package_id']})
 
-        if pkg_dict['state'] == 'draft':
+        if pkg_dict['state'] == 'draft' and not data_dict.get('keepDraft'):
             toolkit.get_action('package_patch')(
                 dict(context.copy(), allow_state_change=True),
                 dict(id=pkg_dict['id'], state='active')


### PR DESCRIPTION
- Added a parameter `keepDraft` to `cloudstorage_finish_multipart` action that keeps the dataset as a draft if it was so before
- Modified `_onFinishUpload` to send `keepDraft=true` if the pressed save button was not the finish button