### PR TITLE
AV-1486: AWS boto3 sessions

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,6 +18,7 @@ setup(
     zip_safe=False,
     install_requires=[
         'apache-libcloud==1.5.0',
+        'boto3==1.17.112',
         'ckanapi'
     ],
     entry_points=(


### PR DESCRIPTION
Add support for AWS IAM session creation via boto3 library.

This makes it possible to use the extension easily in services such as AWS Fargate. This is because boto3 can automatically create a session using metadata available inside a Fargate container environment.