### PR TITLE
Fix empty files in update

### DIFF
--- a/ckanext/cloudstorage/fanstatic/scripts/cloudstorage-multipart-upload.js
+++ b/ckanext/cloudstorage/fanstatic/scripts/cloudstorage-multipart-upload.js
@@ -246,29 +246,14 @@ ckan.module('cloudstorage-multipart-upload', function($, _) {
             }
             event.preventDefault();
 
-            var dataset_id = this.options.packageId;
-            this._btnClick = $(event.target).attr('value');
-            if (this._btnClick == 'go-dataset') {
-
+            try{
+                this._onDisableSave(true);
+                this._pressedSaveButton = $(event.target).attr('value');
+                this._onSaveForm();
+            } catch(error){
+                console.log(error);
                 this._onDisableSave(false);
-                var redirect_url = this.sandbox.url(
-                    '/dataset/edit/' +
-                    dataset_id);
-
-                window.setTimeout(function(){
-                    window.location = redirect_url;
-                }, 1000);
-            } else {
-                try{
-                    this._onDisableSave(true);
-                    this._onSaveForm();
-                } catch(error){
-                    console.log(error);
-                    this._onDisableSave(false);
-                }
             }
-
-            // this._form.trigger('submit', true);
         },
 
         _onSaveForm: function() {
@@ -378,7 +363,8 @@ ckan.module('cloudstorage-multipart-upload', function($, _) {
                 {
                     'uploadId': this._uploadId,
                     'id': this._resourceId,
-                    'keepDraft': keepDraft
+                    'keepDraft': keepDraft,
+                    'save_action': this._pressedSaveButton
                 },
                 function (data) {
 

--- a/ckanext/cloudstorage/logic/action/multipart.py
+++ b/ckanext/cloudstorage/logic/action/multipart.py
@@ -224,7 +224,6 @@ def finish_multipart(context, data_dict):
     upload.delete()
     upload.commit()
 
-    log.info(save_action)
     if save_action and save_action == "go-metadata":
         try:
             res_dict = toolkit.get_action('resource_show')(
@@ -232,7 +231,6 @@ def finish_multipart(context, data_dict):
             pkg_dict = toolkit.get_action('package_show')(
                 context.copy(), {'id': res_dict['package_id']})
 
-            log.info(toolkit.asbool(data_dict.get('keepDraft')))
             if pkg_dict['state'] == 'draft' and not toolkit.asbool(data_dict.get('keepDraft')):
                 toolkit.get_action('package_patch')(
                     dict(context.copy(), allow_state_change=True),

--- a/ckanext/cloudstorage/logic/action/multipart.py
+++ b/ckanext/cloudstorage/logic/action/multipart.py
@@ -224,6 +224,7 @@ def finish_multipart(context, data_dict):
     upload.delete()
     upload.commit()
 
+    log.info(save_action)
     if save_action and save_action == "go-metadata":
         try:
             res_dict = toolkit.get_action('resource_show')(
@@ -231,6 +232,7 @@ def finish_multipart(context, data_dict):
             pkg_dict = toolkit.get_action('package_show')(
                 context.copy(), {'id': res_dict['package_id']})
 
+            log.info(toolkit.asbool(data_dict.get('keepDraft')))
             if pkg_dict['state'] == 'draft' and not toolkit.asbool(data_dict.get('keepDraft')):
                 toolkit.get_action('package_patch')(
                     dict(context.copy(), allow_state_change=True),

--- a/ckanext/cloudstorage/storage.py
+++ b/ckanext/cloudstorage/storage.py
@@ -21,8 +21,7 @@ from libcloud.storage.providers import get_driver
 
 from werkzeug.datastructures import FileStorage as FlaskFileStorage
 ALLOWED_UPLOAD_TYPES = (cgi.FieldStorage, FlaskFileStorage)
-import logging
-log = logging.getLogger(__name__)
+
 
 def _get_underlying_file(wrapper):
     if isinstance(wrapper, FlaskFileStorage):
@@ -296,6 +295,7 @@ class ResourceCloudStorage(CloudStorage):
         :param max_size: Ignored.
         """
         if self.filename:
+
             if self.can_use_advanced_azure:
                 from azure.storage import blob as azure_blob
                 from azure.storage.blob.models import ContentSettings

--- a/ckanext/cloudstorage/storage.py
+++ b/ckanext/cloudstorage/storage.py
@@ -21,7 +21,8 @@ from libcloud.storage.providers import get_driver
 
 from werkzeug.datastructures import FileStorage as FlaskFileStorage
 ALLOWED_UPLOAD_TYPES = (cgi.FieldStorage, FlaskFileStorage)
-
+import logging
+log = logging.getLogger(__name__)
 
 def _get_underlying_file(wrapper):
     if isinstance(wrapper, FlaskFileStorage):
@@ -244,7 +245,7 @@ class ResourceCloudStorage(CloudStorage):
         multipart_name = resource.pop('multipart_name', None)
 
         # Check to see if a file has been provided
-        if isinstance(upload_field_storage, (ALLOWED_UPLOAD_TYPES)):
+        if bool(upload_field_storage) and isinstance(upload_field_storage, ALLOWED_UPLOAD_TYPES):
             self.filename = munge.munge_filename(upload_field_storage.filename)
             self.file_upload = _get_underlying_file(upload_field_storage)
             resource['url'] = self.filename
@@ -295,7 +296,6 @@ class ResourceCloudStorage(CloudStorage):
         :param max_size: Ignored.
         """
         if self.filename:
-
             if self.can_use_advanced_azure:
                 from azure.storage import blob as azure_blob
                 from azure.storage.blob.models import ContentSettings


### PR DESCRIPTION
In CKAN 2.9 upload_file_storage contains a file object but it may be empty.
Also fixes state handling in javascript, before this dataset would stay in draft state.