### PR TITLE
Submit to datapusher in uploader

### DIFF
--- a/ckanext/cloudstorage/storage.py
+++ b/ckanext/cloudstorage/storage.py
@@ -18,7 +18,7 @@ import ckan.plugins as p
 from libcloud.storage.types import Provider, ObjectDoesNotExistError
 from libcloud.storage.providers import get_driver
 
-
+from .utils import submit_to_datapusher
 from werkzeug.datastructures import FileStorage as FlaskFileStorage
 ALLOWED_UPLOAD_TYPES = (cgi.FieldStorage, FlaskFileStorage)
 
@@ -341,6 +341,8 @@ class ResourceCloudStorage(CloudStorage):
                 object_name = self.path_from_filename(id, self.filename)
                 self.container.upload_object_via_stream(iterator=file_upload_iter,
                                                         object_name=object_name)
+
+                submit_to_datapusher(resource_id=id)
 
         elif self._clear and self.old_filename and not self.leave_files:
             # This is only set when a previously-uploaded file is replace

--- a/ckanext/cloudstorage/utils.py
+++ b/ckanext/cloudstorage/utils.py
@@ -7,13 +7,14 @@ from ckan import logic, model
 import ckan.plugins.toolkit as tk
 from ckan.lib import base, uploader
 import ckan.lib.helpers as h
+from ckan.plugins import plugin_loaded
 import cgi
 import tempfile
 from ckan.logic import NotFound
 from ckanapi import LocalCKAN
 
 from ckanext.cloudstorage.model import (create_tables, drop_tables)
-from ckanext.cloudstorage.storage import (CloudStorage, ResourceCloudStorage)
+import ckanext.cloudstorage.storage as storage
 
 
 if tk.check_ckan_version("2.9"):
@@ -32,7 +33,7 @@ def initdb():
 
 
 def fix_cors(domains):
-    cs = CloudStorage()
+    cs = storage.CloudStorage()
 
     if cs.can_use_advanced_azure:
         from azure.storage import blob as azure_blob
@@ -105,7 +106,7 @@ def migrate(path, single_id):
             resource['upload'] = FakeFileStorage(
                 fin, resource['url'].split('/')[-1])
             try:
-                uploader = ResourceCloudStorage(resource)
+                uploader = storage.ResourceCloudStorage(resource)
                 uploader.upload(resource['id'])
             except Exception as e:
                 failed.append(resource_id)
@@ -167,3 +168,27 @@ def resource_download(id, resource_id, filename=None):
         return base.abort(404, tk._('No download is available'))
 
     return h.redirect_to(uploaded_url)
+
+def submit_to_datapusher(resource_id=None, res_dict=None):
+    # Submit to datapusher, uses custom config variable which is not triggered automatically in ckan
+    if plugin_loaded('datapusher'):
+        if not res_dict:
+            res_dict = tk.get_action('resource_show')({}, {'id': resource_id})
+
+        resource_format = res_dict.get('format')
+        supported_formats = tk.config.get(
+            'ckanext.cloudstorage.datapusher.formats'
+        )
+
+        submit = (
+            resource_format
+            and resource_format.lower() in supported_formats
+            and res_dict.get('url_type') != u'datapusher'
+        )
+
+        if submit:
+            tk.get_action(u'datapusher_submit')(
+                {'ignore_auth': True}, {
+                    u'resource_id': res_dict['id']
+                }
+            )

--- a/ckanext/cloudstorage/utils.py
+++ b/ckanext/cloudstorage/utils.py
@@ -173,7 +173,7 @@ def submit_to_datapusher(resource_id=None, res_dict=None):
     # Submit to datapusher, uses custom config variable which is not triggered automatically in ckan
     if plugin_loaded('datapusher'):
         if not res_dict:
-            res_dict = tk.get_action('resource_show')({}, {'id': resource_id})
+            res_dict = tk.get_action('resource_show')({'ignore_auth': True}, {'id': resource_id})
 
         resource_format = res_dict.get('format')
         supported_formats = tk.config.get(


### PR DESCRIPTION
The datapusher submit was only used in multipart uploading, this adds it to resource uploader as well which is in use in the API.